### PR TITLE
Relative Pathing Suggested Changes

### DIFF
--- a/auth/admin/classes/common/Utility.php
+++ b/auth/admin/classes/common/Utility.php
@@ -54,15 +54,21 @@ class Utility {
 
 	//returns file path up to /coral/
 	public function getCORALPath(){
-		$pagePath = $_SERVER["DOCUMENT_ROOT"];
-
-		$currentFile = $_SERVER["SCRIPT_NAME"];
+		$documentRoot = rtrim($_SERVER['DOCUMENT_ROOT'],'/\\');
+		$currentFile = $_SERVER['SCRIPT_NAME'];
+		$hasSlash = (substr($currentFile, 0, 1) == '/'); //Confirms whether the currentFile has a leading forward slash.
+		$pathStart = ($hasSlash) ? '' : '/';
+		/* There is a presumption in the code that we are always using every element of the array EXCEPT the last two parts 
+		(typically things like "organizations" ; "index.php"). If there is ever a reason CORALPath is used in a deeper subdirectory 
+		this may need to be modified. However, for now I'm just going to keep the "don't use the last two elements of the array" assumption.
+		One place we know this runs afoul is if the function is called in the root directory of coral itself, where we should only remove the last element.
+		Future improvement for future people!
+		*/
 		$parts = Explode('/', $currentFile);
-		for($i=0; $i<count($parts) - 2; $i++){
-			$pagePath .= $parts[$i] . '/';
-		}
-
-		return $pagePath;
+		$pathArray = array_slice($parts, 0, count($parts)-2);
+		$moduleLessPathString = implode("/", $pathArray);
+		$pathway = $documentRoot.$pathStart.$moduleLessPathString;
+		return $pathway;
 	}
 
 	//returns page URL up to /coral/

--- a/index.php
+++ b/index.php
@@ -32,9 +32,9 @@
 
 	<title><?php echo _("eRM - eResource Management"); ?></title>
 	
-	<link rel="icon" href="<?php echo $coralPath; ?>images/favicon.ico">
-  <link rel="icon" href="<?php echo $coralPath; ?>images/favicon.svg" type="image/svg+xml">
-  <link rel="stylesheet" href="<?php echo $coralPath; ?>css/style.css" type="text/css" media="screen" />
+	<link rel="icon" href="images/favicon.ico">
+  <link rel="icon" href="images/favicon.svg" type="image/svg+xml">
+  <link rel="stylesheet" href="css/style.css" type="text/css" media="screen" />
   <link rel="stylesheet" href="css/indexstyle.css" type="text/css" media="screen" />
 	<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.6.0/jquery.min.js"></script>
 	<script src="js/plugins/Gettext.js"></script>
@@ -104,8 +104,18 @@
 	</article>
 	</main>
 
-	<?php
-	include('templates/footer.php');
-	?>
+	<footer class="footer">
+		<?php echo _("Copyright");?> &copy; <?php echo date('Y'); ?>. <?php echo _("CORAL version");?> 2024.??<br/>
+		<a href="http://coral-erm.org/">
+			<img src="images/coral-erm.svg" role="img" class="logo logo-dark" alt="CORAL eRM project website"/> 
+			<img src="images/coral-erm-light.svg" role="img" class="logo logo-light" alt="CORAL eRM project website"/>
+		</a>
+		<a href="https://github.com/coral-erm/coral/issues" id="report-issue"><?php echo _("Report an Issue");?></a>
+	</footer>
+
+	<script>
+		const CORAL_ILS_LINK=<?php echo $config->ils->ilsConnector ? 1 : 0; ?>;
+		Date.format = '<?php echo return_datepicker_date_format(); ?>';
+	</script>
 </body>
 </html>

--- a/licensing/admin/classes/common/Utility.php
+++ b/licensing/admin/classes/common/Utility.php
@@ -37,15 +37,21 @@ class Utility {
 
 	//returns file path up to /coral/
 	public function getCORALPath(){
-		$pagePath = $_SERVER["DOCUMENT_ROOT"];
-
-		$currentFile = $_SERVER["SCRIPT_NAME"];
+		$documentRoot = rtrim($_SERVER['DOCUMENT_ROOT'],'/\\');
+		$currentFile = $_SERVER['SCRIPT_NAME'];
+		$hasSlash = (substr($currentFile, 0, 1) == '/'); //Confirms whether the currentFile has a leading forward slash.
+		$pathStart = ($hasSlash) ? '' : '/';
+		/* There is a presumption in the code that we are always using every element of the array EXCEPT the last two parts 
+		(typically things like "organizations" ; "index.php"). If there is ever a reason CORALPath is used in a deeper subdirectory 
+		this may need to be modified. However, for now I'm just going to keep the "don't use the last two elements of the array" assumption.
+		One place we know this runs afoul is if the function is called in the root directory of coral itself, where we should only remove the last element.
+		Future improvement for future people!
+		*/
 		$parts = Explode('/', $currentFile);
-		for($i=0; $i<count($parts) - 2; $i++){
-			$pagePath .= $parts[$i] . '/';
-		}
-
-		return $pagePath;
+		$pathArray = array_slice($parts, 0, count($parts)-2);
+		$moduleLessPathString = implode("/", $pathArray);
+		$pathway = $documentRoot.$pathStart.$moduleLessPathString;
+		return $pathway;
 	}
 
 	//returns file path for this module, i.e. /coral/licensing/

--- a/management/admin/classes/common/Utility.php
+++ b/management/admin/classes/common/Utility.php
@@ -37,15 +37,21 @@ class Utility {
 
 	//returns file path up to /coral/
 	public function getCORALPath(){
-		$pagePath = $_SERVER["DOCUMENT_ROOT"];
-
-		$currentFile = $_SERVER["SCRIPT_NAME"];
+		$documentRoot = rtrim($_SERVER['DOCUMENT_ROOT'],'/\\');
+		$currentFile = $_SERVER['SCRIPT_NAME'];
+		$hasSlash = (substr($currentFile, 0, 1) == '/'); //Confirms whether the currentFile has a leading forward slash.
+		$pathStart = ($hasSlash) ? '' : '/';
+		/* There is a presumption in the code that we are always using every element of the array EXCEPT the last two parts 
+		(typically things like "organizations" ; "index.php"). If there is ever a reason CORALPath is used in a deeper subdirectory 
+		this may need to be modified. However, for now I'm just going to keep the "don't use the last two elements of the array" assumption.
+		One place we know this runs afoul is if the function is called in the root directory of coral itself, where we should only remove the last element.
+		Future improvement for future people!
+		*/
 		$parts = Explode('/', $currentFile);
-		for($i=0; $i<count($parts) - 2; $i++){
-			$pagePath .= $parts[$i] . '/';
-		}
-
-		return $pagePath;
+		$pathArray = array_slice($parts, 0, count($parts)-2);
+		$moduleLessPathString = implode("/", $pathArray);
+		$pathway = $documentRoot.$pathStart.$moduleLessPathString;
+		return $pathway;
 	}
 
 	//returns file path for this module, i.e. /coral/licensing/

--- a/organizations/admin/classes/common/Utility.php
+++ b/organizations/admin/classes/common/Utility.php
@@ -54,15 +54,21 @@ class Utility {
 
 	//returns file path up to /coral/
 	public function getCORALPath(){
-                $pagePath = rtrim($_SERVER['DOCUMENT_ROOT'],'/\\').'/';
-
-		$currentFile = $_SERVER["SCRIPT_NAME"];
+		$documentRoot = rtrim($_SERVER['DOCUMENT_ROOT'],'/\\');
+		$currentFile = $_SERVER['SCRIPT_NAME'];
+		$hasSlash = (substr($currentFile, 0, 1) == '/'); //Confirms whether the currentFile has a leading forward slash.
+		$pathStart = ($hasSlash) ? '' : '/';
+		/* There is a presumption in the code that we are always using every element of the array EXCEPT the last two parts 
+		(typically things like "organizations" ; "index.php"). If there is ever a reason CORALPath is used in a deeper subdirectory 
+		this may need to be modified. However, for now I'm just going to keep the "don't use the last two elements of the array" assumption.
+		One place we know this runs afoul is if the function is called in the root directory of coral itself, where we should only remove the last element.
+		Future improvement for future people!
+		*/
 		$parts = Explode('/', $currentFile);
-		for($i=0; $i<count($parts) - 2; $i++){
-			$pagePath .= $parts[$i] . '/';
-		}
-
-		return $pagePath;
+		$pathArray = array_slice($parts, 0, count($parts)-2);
+		$moduleLessPathString = implode("/", $pathArray);
+		$pathway = $documentRoot.$pathStart.$moduleLessPathString;
+		return $pathway;
 	}
 
 	//returns page URL up to /coral/

--- a/organizations/templates/footer.php
+++ b/organizations/templates/footer.php
@@ -17,7 +17,7 @@
 **************************************************************************************************************************
 */
 
-
+/* This is set up in index.php for Organizations.
 //used to default to previously selected values when back button is pressed
 //if the startWith is defined set it so that it will default to the first letter picked
 if ((CoralSession::get('res_startWith')) && ($reset != 'Y')){
@@ -36,6 +36,6 @@ if ((CoralSession::get('res_recordsPerPage')) && ($reset != 'Y')){
 if ((CoralSession::get('res_orderBy')) && ($reset != 'Y')){
   echo "orderBy = \"" . CoralSession::get('res_orderBy') . "\";";
 }
-
+*/
 include '../templates/footer.php'; 
 ?>

--- a/organizations/templates/header.php
+++ b/organizations/templates/header.php
@@ -18,8 +18,8 @@
 */
 
 /* CORAL setup */
-include_once $_SERVER['DOCUMENT_ROOT'].'/coral/organizations/directory.php';
-include_once $_SERVER['DOCUMENT_ROOT'].'/coral/organizations/user.php';
+include_once 'directory.php';
+include_once 'user.php';
 
 /* module setup */
 $moduleTitle = _('Organizations');

--- a/reports/admin/classes/common/Utility.php
+++ b/reports/admin/classes/common/Utility.php
@@ -37,15 +37,21 @@ class Utility {
 
 	//returns file path up to /coral/
 	public function getCORALPath(){
-		$pagePath = $_SERVER["DOCUMENT_ROOT"];
-
-		$currentFile = $_SERVER["SCRIPT_NAME"];
+		$documentRoot = rtrim($_SERVER['DOCUMENT_ROOT'],'/\\');
+		$currentFile = $_SERVER['SCRIPT_NAME'];
+		$hasSlash = (substr($currentFile, 0, 1) == '/'); //Confirms whether the currentFile has a leading forward slash.
+		$pathStart = ($hasSlash) ? '' : '/';
+		/* There is a presumption in the code that we are always using every element of the array EXCEPT the last two parts 
+		(typically things like "organizations" ; "index.php"). If there is ever a reason CORALPath is used in a deeper subdirectory 
+		this may need to be modified. However, for now I'm just going to keep the "don't use the last two elements of the array" assumption.
+		One place we know this runs afoul is if the function is called in the root directory of coral itself, where we should only remove the last element.
+		Future improvement for future people!
+		*/
 		$parts = Explode('/', $currentFile);
-		for($i=0; $i<count($parts) - 2; $i++){
-			$pagePath .= $parts[$i] . '/';
-		}
-
-		return $pagePath;
+		$pathArray = array_slice($parts, 0, count($parts)-2);
+		$moduleLessPathString = implode("/", $pathArray);
+		$pathway = $documentRoot.$pathStart.$moduleLessPathString;
+		return $pathway;
 	}
 
 	//returns file path for this module, i.e. /coral/licensing/

--- a/resources/admin/classes/common/Utility.php
+++ b/resources/admin/classes/common/Utility.php
@@ -54,17 +54,21 @@ class Utility {
 
 	//returns file path up to /coral/
 	public function getCORALPath(){
-		$pagePath = rtrim($_SERVER['DOCUMENT_ROOT'],'/\\').'/';
-
-		$currentFile = $_SERVER["SCRIPT_NAME"];
+		$documentRoot = rtrim($_SERVER['DOCUMENT_ROOT'],'/\\');
+		$currentFile = $_SERVER['SCRIPT_NAME'];
+		$hasSlash = (substr($currentFile, 0, 1) == '/'); //Confirms whether the currentFile has a leading forward slash.
+		$pathStart = ($hasSlash) ? '' : '/';
+		/* There is a presumption in the code that we are always using every element of the array EXCEPT the last two parts 
+		(typically things like "organizations" ; "index.php"). If there is ever a reason CORALPath is used in a deeper subdirectory 
+		this may need to be modified. However, for now I'm just going to keep the "don't use the last two elements of the array" assumption.
+		One place we know this runs afoul is if the function is called in the root directory of coral itself, where we should only remove the last element.
+		Future improvement for future people!
+		*/
 		$parts = Explode('/', $currentFile);
-		for($i=0; $i<count($parts) - 2; $i++){
-			if ($parts[$i] != '' && $parts[$i] !='resources'){
-				$pagePath .= $parts[$i] . '/';
-			}
-		}
-
-		return $pagePath;
+		$pathArray = array_slice($parts, 0, count($parts)-2);
+		$moduleLessPathString = implode("/", $pathArray);
+		$pathway = $documentRoot.$pathStart.$moduleLessPathString;
+		return $pathway;
 	}
 
 	//returns page URL up to /coral/

--- a/resources/templates/header.php
+++ b/resources/templates/header.php
@@ -19,7 +19,7 @@
 
 
 /* CORAL setup */
-include_once $_SERVER['DOCUMENT_ROOT'].'/coral/resources/user.php';
+include_once 'user.php';
 
 $util = new Utility();
 $config = new Configuration();

--- a/templates/footer.php
+++ b/templates/footer.php
@@ -24,8 +24,8 @@
 <footer class="footer">
   <?php echo _("Copyright");?> &copy; <?php echo date('Y'); ?>. <?php echo _("CORAL version");?> 2024.??<br/>
   <a href="http://coral-erm.org/">
-    <img src="/coral/images/coral-erm.svg" role="img" class="logo logo-dark" alt="CORAL eRM project website"/> 
-    <img src="/coral/images/coral-erm-light.svg" role="img" class="logo logo-light" alt="CORAL eRM project website"/>
+    <img src="<?php echo $coralPath; ?>images/coral-erm.svg" role="img" class="logo logo-dark" alt="CORAL eRM project website"/> 
+    <img src="<?php echo $coralPath; ?>images/coral-erm-light.svg" role="img" class="logo logo-light" alt="CORAL eRM project website"/>
   </a>
   <a href="https://github.com/coral-erm/coral/issues" id="report-issue"><?php echo _("Report an Issue");?></a>
 </footer>

--- a/templates/header.php
+++ b/templates/header.php
@@ -131,8 +131,8 @@ global $http_lang;
     <a href="#main-content" class="skip"><?php echo _('Skip to main content'); ?></a>
     <h1>
       <a href="<?php echo $coralPath; ?>" class="site-title-link">
-        <img src="/coral/images/coral-erm.svg" role="img" class="logo logo-dark" alt="CORAL eRM"/> 
-        <img src="/coral/images/coral-erm-light.svg" role="img" class="logo logo-light" alt="CORAL eRM"/>
+        <img src="<?php echo $coralPath; ?>/images/coral-erm.svg" role="img" class="logo logo-dark" alt="CORAL eRM"/> 
+        <img src="<?php echo $coralPath; ?>/images/coral-erm-light.svg" role="img" class="logo logo-light" alt="CORAL eRM"/>
       </a>
       <a href="<?php echo $coralPath . $modulePath; ?>/" class="module-title-link">
         <?php echo $moduleTitle; ?>
@@ -228,7 +228,7 @@ global $http_lang;
 <nav id="main" aria-label="<?php echo _("Modules"); ?>">
   <button class="btn menu-toggle" id="modules-toggle" type="button" aria-expanded="false" aria-controls="modules"><?php echo _("Modules"); ?></button>
   <ul class="nav" id="modules">
-    <?php if (file_exists($util->getCORALPath() . "index.php")) { 
+    <?php if (file_exists($util->getCORALPath() . "/index.php")) { 
       if ($currentModule == $coralPath) {
         $ariaCurrentModule = 'aria-current="page"';
       }

--- a/templates/header.php
+++ b/templates/header.php
@@ -131,8 +131,8 @@ global $http_lang;
     <a href="#main-content" class="skip"><?php echo _('Skip to main content'); ?></a>
     <h1>
       <a href="<?php echo $coralPath; ?>" class="site-title-link">
-        <img src="<?php echo $coralPath; ?>/images/coral-erm.svg" role="img" class="logo logo-dark" alt="CORAL eRM"/> 
-        <img src="<?php echo $coralPath; ?>/images/coral-erm-light.svg" role="img" class="logo logo-light" alt="CORAL eRM"/>
+        <img src="<?php echo $coralPath; ?>images/coral-erm.svg" role="img" class="logo logo-dark" alt="CORAL eRM"/> 
+        <img src="<?php echo $coralPath; ?>images/coral-erm-light.svg" role="img" class="logo logo-light" alt="CORAL eRM"/>
       </a>
       <a href="<?php echo $coralPath . $modulePath; ?>/" class="module-title-link">
         <?php echo $moduleTitle; ?>

--- a/usage/admin/classes/common/Utility.php
+++ b/usage/admin/classes/common/Utility.php
@@ -54,15 +54,21 @@ class Utility {
 
 	//returns file path up to /coral/
 	static public function getCORALPath(){
-		$pagePath = $_SERVER["DOCUMENT_ROOT"];
-
-		$currentFile = $_SERVER["SCRIPT_NAME"];
+		$documentRoot = rtrim($_SERVER['DOCUMENT_ROOT'],'/\\');
+		$currentFile = $_SERVER['SCRIPT_NAME'];
+		$hasSlash = (substr($currentFile, 0, 1) == '/'); //Confirms whether the currentFile has a leading forward slash.
+		$pathStart = ($hasSlash) ? '' : '/';
+		/* There is a presumption in the code that we are always using every element of the array EXCEPT the last two parts 
+		(typically things like "organizations" ; "index.php"). If there is ever a reason CORALPath is used in a deeper subdirectory 
+		this may need to be modified. However, for now I'm just going to keep the "don't use the last two elements of the array" assumption.
+		One place we know this runs afoul is if the function is called in the root directory of coral itself, where we should only remove the last element.
+		Future improvement for future people!
+		*/
 		$parts = Explode('/', $currentFile);
-		for($i=0; $i<count($parts) - 2; $i++){
-			$pagePath .= $parts[$i] . '/';
-		}
-
-		return $pagePath;
+		$pathArray = array_slice($parts, 0, count($parts)-2);
+		$moduleLessPathString = implode("/", $pathArray);
+		$pathway = $documentRoot.$pathStart.$moduleLessPathString;
+		return $pathway;
 	}
 
 	//returns page URL up to /coral/

--- a/usage/templates/footer.php
+++ b/usage/templates/footer.php
@@ -1,6 +1,7 @@
 <?php
 //used to default to previously selected values when back button is pressed
 //if the startWith is defined set it so that it will default to the first letter picked
+/*
 if ((CoralSession::get('res_startWith')) && ($reset != 'Y')){
   echo "startWith = '" . CoralSession::get('res_startWith') . "';";
   echo "$(\"#span_letter_" . CoralSession::get('res_startWith') . "\").removeClass('searchLetter').addClass('searchLetterSelected');";
@@ -17,6 +18,6 @@ if ((CoralSession::get('res_recordsPerPage')) && ($reset != 'Y')){
 if ((CoralSession::get('res_orderBy')) && ($reset != 'Y')){
   echo "orderBy = \"" . CoralSession::get('res_orderBy') . "\";";
 }
-
+*/
 include '../templates/footer.php'; 
 ?>

--- a/usage/templates/header.php
+++ b/usage/templates/header.php
@@ -17,8 +17,9 @@
 */
 
 /* CORAL setup */
-include_once "user.php";
 include_once 'directory.php';
+include_once "user.php";
+
 
 $util = new Utility();
 $config = new Configuration();

--- a/usage/templates/header.php
+++ b/usage/templates/header.php
@@ -17,8 +17,8 @@
 */
 
 /* CORAL setup */
-include_once $_SERVER['DOCUMENT_ROOT'].'/coral/usage/directory.php';
-include_once $_SERVER['DOCUMENT_ROOT'].'/coral/usage/user.php';
+include_once "user.php";
+include_once 'directory.php';
 
 $util = new Utility();
 $config = new Configuration();


### PR DESCRIPTION
Resolves stephanieleary/coral-a11y-cleanup-2024#1
Includes a series of commits that primarily revert some template/header files from absolute to relative pathing. I was able to test Organizations, Licensing, Resources, and Usage Stats modules - not tested are the Reports and Management modules. The auth module was lightly tested (no real revisions so I just went into /auth/index.php and didn't get a 500 error). 

- Refactors the Utility->getCORALPath() function
  - The previous version functioned, this was primarily done to remove a duplicated forward slash and add contextual comments about potential future development.
- Hardcodes the footer for the Main CORAL index.php
   - The largest difficulty with this was that the main page's footer could not use the aforementioned getCORALPath() function; since the header for the page was unique and hardcoded, I opted to hardcode in the footer (even though it's a duplication of code). I think if getCORALPath() can be better refactored in the future, it might solve this.
- Comments out duplicated Session variables in the Organizations and Usage footers.
  - The Resources module commented out a lot of code that was using Session Variables to, I think, create the forward/back lists in the module's footer code. This code was instead in the index.php file for the module. Both Organizations and Usage had the same code in their index.php files but it wasn't commented out in the Footers. On my machine this prevented the footer file from running, so I commented it out (like it was in the Resources).
- Removes $_SERVER['DOCUMENT_ROOT'] pathing from Organizations, Resources, and Usage headers.
   - As referenced in Issue #1 - removes the absolute paths and allows the coral folder structure to sit in deeper subdirectories (or even in the root directory without the overarching coral repo folder) 
- Adds $coralPath variable to the commonly shared footer and header templates.
  - For links to the CORAL icon, I used the $coralPath value as a prefix for the paths. 

I tested the repo: 
- pulled into the root directory without the coral folder; 
- pulled into the root directory inside the coral folder; 
- pulled into the coral folder two and three subdirectories deep. 