### PR TITLE
Resolves #714. 

### DIFF
--- a/resources/admin/classes/domain/AuthenticationType.php
+++ b/resources/admin/classes/domain/AuthenticationType.php
@@ -26,10 +26,8 @@ class AuthenticationType extends DatabaseObject {
 	//returns number of children
 	public function getNumberOfChildren(){
 
-		$query = "SELECT count(*) childCount FROM Resource WHERE authenticationTypeID = '" . $this->authenticationTypeID . "';";
-
+		$query = "SELECT count(*) childCount FROM ResourceAcquisition WHERE authenticationTypeID = '" . $this->authenticationTypeID . "';";
 		$result = $this->db->processQuery($query, 'assoc');
-
 		return $result['childCount'];
 
 	}


### PR DESCRIPTION
Resolves [coral-erm#714](https://github.com/coral-erm/coral/issues/714)
Corrects the table where the AuthenticationTypeIDs are being stored. Since AuthenticationTypeIDs isn't a column in Resources it was stopping the getNumberOfChildren() function, which in turn prevented the delete function from completing. 