### PR TITLE
Helpful Links Revision - Resolves #626

### DIFF
--- a/licensing/ajax_htmldata.php
+++ b/licensing/ajax_htmldata.php
@@ -1625,38 +1625,37 @@ switch ($_GET['action']) {
 		$licenseID = $_GET['licenseID'];
 		$license = new License(new NamedArguments(array('primaryKey' => $licenseID)));
 		$config = new Configuration;
-
 		//get resources (already returned in array)
 		$resourceArray = $license->getResourceArray();
-		$resourcesExist = count($resourcesArray) > 0;
+		$resourcesExist = count($resourceArray) > 0;
 		$resourcesModuleExists = $config->settings->resourcesModule == 'Y';
 		$feedbackEmail = $config->settings->feedbackEmailAddress;
 		$feedbackEmailExists = $feedbackEmail != '';
-		$licenseName = '';
-		$licenseID = '';
-
 		if(($resourcesExist && $resourcesModuleExists) || $feedbackEmailExists){
 			?>
 			<aside id="links" class="helpfulLinks">
 				<div id='div_fullRightPanel' class='rightPanel'>
 					<h3 id="side-menu-title"><?php echo _("Helpful Links"); ?></h3>
-					<?php if($resourcesExist) { ?>
+					<?php if($resourcesExist) { 
+						//First we need to de-deduplicate the resources Array. It can be duplicated if there are multiple orders of a single resource.
+						$deDupedList = [];
+						foreach($resourceArray as $resource){$deDupedList[$resource['resourceID']] = $resource['resource'];}
+						?>
 						<h4><?php echo _("Resources Module");?></h4>
 						<ul class="unstyled">
-							<?php foreach($resourceArray as $resource){
+							<?php foreach($deDupedList as $id=>$resourceName){
 								$url = $util->getResourceURL();
 								$target = getTarget();
-								$id = $resource['resourceID'];
-								$resourceName = $resource['resource'];
 								echo "<li><a href='{$url}{$id}' {$target} class='helpfulLink'>{$resourceName}</a></li>";
 							} ?>
 						</ul>
 					<?php } ?>
+					<?php if($resourcesExist && $feedbackEmailExists){echo "<hr>";} ?>
 					<?php if($feedbackEmailExists) { ?>
 						<p>
 							<?php 
-								echo "<a href='mailto:{$feedbackEmail}?subject={$licenseName} (License ID: {$licenseID})' class='helpfulLink'>"; 
-									echo _("Send feedback on this resource");
+								echo "<a href='mailto:{$feedbackEmail}?subject={$license->shortName} (License ID: {$licenseID})' class='helpfulLink'>"; 
+									echo _("Send feedback on this license");
 								echo "</a>";
 							?>
 						</p>

--- a/licensing/ajax_htmldata.php
+++ b/licensing/ajax_htmldata.php
@@ -1628,25 +1628,45 @@ switch ($_GET['action']) {
 
 		//get resources (already returned in array)
 		$resourceArray = $license->getResourceArray();
+		$resourcesExist = count($resourcesArray) > 0;
+		$resourcesModuleExists = $config->settings->resourcesModule == 'Y';
+		$feedbackEmail = $config->settings->feedbackEmailAddress;
+		$feedbackEmailExists = $feedbackEmail != '';
+		$licenseName = '';
+		$licenseID = '';
 
-		if ((count($resourceArray) > 0) && ($config->settings->resourcesModule == 'Y')) {
-
-		?>
-			<aside id="links">
-				<h3><?php echo _("Resources Module");?></h3>
-				<ul class="unstyled">
-				<?php
-				foreach ($resourceArray as $resource){
-					echo "<li><a href='" . $util->getResourceURL() . $resource['resourceID'] . "' " . getTarget() . " class='helpfulLink'>" . $resource['resource'] . "</a></li>";
-				}
-
-				?>
-				</ul>
+		if(($resourcesExist && $resourcesModuleExists) || $feedbackEmailExists){
+			?>
+			<aside id="links" class="helpfulLinks">
+				<div id='div_fullRightPanel' class='rightPanel'>
+					<h3 id="side-menu-title"><?php echo _("Helpful Links"); ?></h3>
+					<?php if($resourcesExist) { ?>
+						<h4><?php echo _("Resources Module");?></h4>
+						<ul class="unstyled">
+							<?php foreach($resourceArray as $resource){
+								$url = $util->getResourceURL();
+								$target = getTarget();
+								$id = $resource['resourceID'];
+								$resourceName = $resource['resource'];
+								echo "<li><a href='{$url}{$id}' {$target} class='helpfulLink'>{$resourceName}</a></li>";
+							} ?>
+						</ul>
+					<?php } ?>
+					<?php if($feedbackEmailExists) { ?>
+						<p>
+							<?php 
+								echo "<a href='mailto:{$feedbackEmail}?subject={$licenseName} (License ID: {$licenseID})' class='helpfulLink'>"; 
+									echo _("Send feedback on this resource");
+								echo "</a>";
+							?>
+						</p>
+					<?php } ?>
+				</div>
 			</aside>
 
-		<?php
 
-	}
+			<?php 
+		}
 
 		break;
 

--- a/licensing/license.php
+++ b/licensing/license.php
@@ -83,18 +83,7 @@ if ($license->shortName){
 		</div>
 
 	</article>
-
-	<?php if ($config->settings->feedbackEmailAddress != '') {?>
-	<aside id="links" class='helpfulLinks'>
-		<div id='div_fullRightPanel' class='rightPanel'>
-			<h3 id="side-menu-title"><?php echo _("Helpful Links"); ?></h3>
-			<div id='div_rightPanel'>
-				<p>
-					<a href="mailto: <?php echo $config->settings->feedbackEmailAddress; ?>?subject=<?php echo $resource->titleText . ' (Resource ID: ' . $resource->resourceID . ')'; ?>" class='helpfulLink'><?php echo _("Send feedback on this resource");?></a>
-				</p>
-			</div>
-	</aside>
-	<?php } ?>
+	<div id="div_rightPanel"></div>
 
 	<nav id="side" aria-label="<?php echo _('License Details'); ?>">
 		<!-- TODO: WAI-ARIA Tab Panel -->


### PR DESCRIPTION
The stemmed from [CORAL Issue #626](https://github.com/coral-erm/coral/issues/626). While looking over the "Helpful Links" portion of the licensing module, I noticed that in both this and the older code, we were checking for whether a feedbackEmailAddress setting existed in the licensing module. In both cases, this appeared to be a holdover from when the Helpful Links code was (I assume) copied from the resources module, which has that setting. Licensing does not.

I moved the code around a little bit to combine the assembly of the Helpful Links tab. I also adjusted the IF/THEN statements so that Helpful Links will still appear if a license is attached to resources. Even though feedbackEmailAddress doesn't exist as a licensing setting by default, I kept that code in on the off-chance that someone has manually adjusted their settings to turn the feature on; beyond that I revised the mailto link it generates to use the license information rather than the resource information. 

After testing it appears that the actual meat of the Issue (to have the Helpful Links tab show up in every tab for a license) was already resolved in the A11Y changes, so that should be good to go!