### PR TITLE
Updates resources/admin.js (Resolves Issue #652)

### DIFF
--- a/resources/js/admin.js
+++ b/resources/js/admin.js
@@ -238,15 +238,18 @@ function updateEbscoKbConfigTable(){
 
 function submitData(){
     if (validateAdminForms() === true) {
+        //The stats addition requires special checking.
+        let statsCheck = $('#stats:checkbox:checked');
+        let statsValue = (statsCheck.length > 0);
         $.ajax({
             type:       "POST",
             url:        "ajax_processing.php?action=updateData",
             cache:      false,
-            data:       { className: $("#editClassName").val(), updateID: $("#editUpdateID").val(), shortName: $('#updateVal').val(), stats: $('#stats').attr('checked') },
+            data:       { className: $("#editClassName").val(), updateID: $("#editUpdateID").val(), shortName: $('#updateVal').val(), stats: statsValue },
             success:    function(html) {
                 updateTable($("#editClassName").val());
-        	myDialogPOST();
-	    }
+        	    myDialogPOST();
+	        }
         });
     }
 }


### PR DESCRIPTION
Updates the stats check for the Resources Admin Resource Type form mentioned in [Coral ERM Issue 652](https://github.com/coral-erm/coral/issues/652). What ended being the issue was that the form processing javascript was just checking to see if the checked attribute existed for the stats box (if it displayed) - according to MDN, that attribute provided a boolean which only determines if the checkbox is checked when the page loads, not whether it was checked at the time of form submission. Instead, I swapped it for a test that appears to check the IDL attribute, which _does_ change the value when a user checks or unchecks the box. 

