### PR TITLE
Resolves Issue 723 and Adds Line Item Limits

### DIFF
--- a/usage/admin.php
+++ b/usage/admin.php
@@ -32,6 +32,12 @@ if ($user->isAdmin()){
   <div id='div_emailAddresses'>
     <img src = "images/circle.gif"><?php echo _("Loading...");?>
   </div>
+  <h3 class="headerText"><?php echo _("Line Limits for File Upload/SUSHI Import Confirmations"); ?></h3>
+  <p id="span_Limit_response"></p>
+  <div id="div_limit">
+    <img src="images/circle.gif"><?php echo _("Loading...");?>
+  </div>
+
 
   <h3 class="headerText"><?php echo _("Outlier Parameters");?></h3>
   <p id='span_Outlier_response'></p>

--- a/usage/ajax_htmldata.php
+++ b/usage/ajax_htmldata.php
@@ -1327,7 +1327,28 @@ switch ($action) {
 		break;
 
 
-
+	//display UserLimits Information for admin screen.
+	case 'getLineLimits':
+		//Get default values (if they are set)
+		$config = new Configuration();
+		$lineLimitSetting = ($config->settings->lineLimit);
+		$lineLimitAmount = intval($config->settings->lineLimitAmount);
+		$lineLimitTurnedOn = ($lineLimitSetting == "Y");
+		$lineLimitDefault = ($lineLimitTurnedOn) ? "checked" : "";
+		$amountInputEnabled = ($lineLimitTurnedOn) ? "" : "disabled";
+		$lineLimitAmount = ($lineLimitAmount > 0) ? $lineLimitAmount : 1;
+		?>
+		<form id="lineLimits">
+			<label for="lineLimitSetting">Turn on Line Limit Settings</label>
+			<input type="checkbox" id="lineLimitSetting" onchange="toggleLimitAmountInput()" name="lineLimit" <?php echo $lineLimitDefault; ?>/>
+			<br><br>
+			<label for="lineLimitAmount">Row Limit Amount:</label>
+			<input id="lineLimitAmount" type="number" name="lineLimitAmount" value="<?php echo $lineLimitAmount; ?>" min="1" <?php echo $amountInputEnabled; ?>/>
+			<br><br>
+			<button class="submit-button primary" type="button" onclick="updateLineLimits()">Update Line Limit Settings</button>
+		</form>
+		<?php
+		break;
 	//display user info for admin screen
 	case 'getAdminUserList':
 

--- a/usage/ajax_processing.php
+++ b/usage/ajax_processing.php
@@ -478,7 +478,32 @@ switch ($action) {
 
         break;
 
-
+	case 'limitLineItems':
+		//Get and validate the settings provided.
+		$lineLimitSet = ($_GET['settingOn']) ?: FALSE;
+		$lineLimitValue = ($lineLimitSet == "true") ? "Y" : "N";
+		$lineAmountSet = ($_GET['lineLimitAmount']) ?: FALSE;
+		$lineAmountValue = intval($lineAmountSet);
+		$path = BASE_DIR . "admin/configuration.ini";
+		function config_set($config_file, $section, $key, $value) {
+			$config_data = parse_ini_file($config_file, true);
+			$config_data[$section][$key] = $value;
+			$new_content = [];
+			foreach ($config_data as $section => $section_content) {
+				$section_content = array_map(function($value, $key) {
+					return "$key=\"$value\"";
+				}, array_values($section_content), array_keys($section_content));
+				$section_content = implode("\n", $section_content);
+				$new_content[] = "[$section]\n$section_content\n";
+			}
+			file_put_contents($config_file, implode("\n", $new_content));
+		}
+		config_set($path, 'settings', 'lineLimit', $lineLimitValue);
+		config_set($path, 'settings', 'lineLimitAmount', "{$lineAmountValue}");
+		echo "<span class='success'>";
+		echo _("Line Limit Settings have been updated.");
+		echo "</span>";
+		break;
     case 'updatePlatformDisplay':
 
 		$platform = new Platform(new NamedArguments(array('primaryKey' => $_GET['updateID'])));
@@ -496,8 +521,6 @@ switch ($action) {
 		}
 
         break;
-
-
 
     case 'updatePlatformDropDown':
 

--- a/usage/js/admin.js
+++ b/usage/js/admin.js
@@ -16,190 +16,216 @@
 */
 
 
- $(document).ready(function(){
+$(document).ready(function(){
 
-      updateUserList();
-      updateLogEmailAddressTable();
-      updateOutlierTable();
+    updateUserList();
+    updateLogEmailAddressTable();
+    updateOutlierTable();
+    getLineLimits();
 
-
- });
-
-
+});
 
 
- function updateUserList(){
+function getLineLimits(){
+  $.ajax({
+      type:       "GET",
+      url:        "ajax_htmldata.php",
+      cache:      false,
+      data:       "action=getLineLimits",
+      success:    function(html) { $('#div_limit').html(html);
+      }
+  });
+}
+function updateLineLimits(){
+    $.ajax({
+        type:       "GET",
+        url:        "ajax_processing.php",
+        cache:      false,
+        data:       "action=limitLineItems&settingOn=" + $('#lineLimitSetting').is(":checked") + "&lineLimitAmount="+ $('#lineLimitAmount').val(),
+        success:    function(html) { 
+            $('#span_Limit_response').html(html);
+            //I kind of hate how this is kind of sequenced but it works (for now). Future development opportunity!
+            setTimeout(function(){$('#span_Limit_response').fadeOut(500);}, 5000);
+            setTimeout(function(){$('#span_Limit_response').html("").fadeIn(1);}, 6000);
+        }
+    });
+}
 
-       $.ajax({
-          type:       "GET",
-          url:        "ajax_htmldata.php",
-          cache:      false,
-          data:       "action=getAdminUserList",
-          success:    function(html) { $('#div_User').html(html);
-          }
-      });
+function updateUserList(){
 
- }
+     $.ajax({
+        type:       "GET",
+        url:        "ajax_htmldata.php",
+        cache:      false,
+        data:       "action=getAdminUserList",
+        success:    function(html) { $('#div_User').html(html);
+        }
+    });
 
-
- function submitUserData(orgLoginID){
-	$.ajax({
-          type:       "GET",
-          url:        "ajax_processing.php",
-          cache:      false,
-          data:       "action=submitUserData&orgLoginID=" + orgLoginID + "&loginID=" + $('#loginID').val() + "&firstName=" + $('#firstName').val() + "&lastName=" + $('#lastName').val() + "&privilegeID=" + $('#privilegeID').val() + "&emailAddressForTermsTool=" + $('#emailAddressForTermsTool').val(),
-          success:    function(html) {
-          updateUserList();
-          myCloseDialog();
-          }
-       });
-
- }
-
- function deleteUser(loginID){
-
- 	if (confirm(_("Do you really want to delete this user?")) == true) {
-
-	       $('#span_User_response').html("<img src = 'images/circle.gif'>&nbsp;&nbsp;" + _("Processing..."));
-	       $.ajax({
-		  type:       "GET",
-		  url:        "ajax_processing.php",
-		  cache:      false,
-		  data:       "action=deleteUser&loginID=" + loginID,
-		  success:    function(html) {
-		  $('#span_User_response').html(html);
-
-		  // close the span in 5 secs
-		  setTimeout("emptyResponse('User');",5000);
-
-		  updateUserList();
-		  }
-	      });
-
-	}
- }
+}
 
 
+function submitUserData(orgLoginID){
+  $.ajax({
+        type:       "GET",
+        url:        "ajax_processing.php",
+        cache:      false,
+        data:       "action=submitUserData&orgLoginID=" + orgLoginID + "&loginID=" + $('#loginID').val() + "&firstName=" + $('#firstName').val() + "&lastName=" + $('#lastName').val() + "&privilegeID=" + $('#privilegeID').val() + "&emailAddressForTermsTool=" + $('#emailAddressForTermsTool').val(),
+        success:    function(html) {
+        updateUserList();
+        myCloseDialog();
+        }
+     });
 
- function updateLogEmailAddressTable(){
+}
 
-       $.ajax({
-          type:       "GET",
-          url:        "ajax_htmldata.php",
-          cache:      false,
-          data:       "action=getLogEmailAddressTable",
-          success:    function(html) {
-          	$('#div_emailAddresses').html(html);
-          }
-      });
+function deleteUser(loginID){
 
- }
+   if (confirm(_("Do you really want to delete this user?")) == true) {
+
+         $('#span_User_response').html("<img src = 'images/circle.gif'>&nbsp;&nbsp;" + _("Processing..."));
+         $.ajax({
+        type:       "GET",
+        url:        "ajax_processing.php",
+        cache:      false,
+        data:       "action=deleteUser&loginID=" + loginID,
+        success:    function(html) {
+        $('#span_User_response').html(html);
+
+        // close the span in 5 secs
+        setTimeout("emptyResponse('User');",5000);
+
+        updateUserList();
+        }
+        });
+
+  }
+}
+
+
+
+function updateLogEmailAddressTable(){
+
+     $.ajax({
+        type:       "GET",
+        url:        "ajax_htmldata.php",
+        cache:      false,
+        data:       "action=getLogEmailAddressTable",
+        success:    function(html) {
+            $('#div_emailAddresses').html(html);
+        }
+    });
+
+}
 
 
 
 function doSubmitLogEmailAddress(){
-    if(validateLogEmail() === true){
-        $.ajax({
-            type:       "GET",
-            url:        "ajax_processing.php",
-            cache:      false,
-            data:       "action=submitLogEmailAddress&logEmailAddressID=" + $('#updateLogEmailAddressID').val() + "&emailAddress=" + encodeURIComponent($('#emailAddress').val()),
-            success:    function(html) {
-                updateLogEmailAddressTable();
-                myCloseDialog();
-            }
-        });
-    }
+  if(validateLogEmail() === true){
+      $.ajax({
+          type:       "GET",
+          url:        "ajax_processing.php",
+          cache:      false,
+          data:       "action=submitLogEmailAddress&logEmailAddressID=" + $('#updateLogEmailAddressID').val() + "&emailAddress=" + encodeURIComponent($('#emailAddress').val()),
+          success:    function(html) {
+              updateLogEmailAddressTable();
+              myCloseDialog();
+          }
+      });
+  }
 }
 
 // Validate Log Email Address
 function validateLogEmail(){
-    if($("#emailAddress").val() == ''){
-        $("#span_errors").html(_('Error - Please enter a value.'));
-        $("#emailAddress").focus();
-        return false;
-    }else if(!/^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z0-9]+$/.test( $("#emailAddress").val() )){
-        $("#span_errors").html(_('Error - Please enter a valid email address.'));
-        $("#emailAddress").focus();
-        return false;
-    }else{
-        return true;
-    }
+  if($("#emailAddress").val() == ''){
+      $("#span_errors").html(_('Error - Please enter a value.'));
+      $("#emailAddress").focus();
+      return false;
+  }else if(!/^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z0-9]+$/.test( $("#emailAddress").val() )){
+      $("#span_errors").html(_('Error - Please enter a valid email address.'));
+      $("#emailAddress").focus();
+      return false;
+  }else{
+      return true;
+  }
 }
 
-  function deleteLogEmailAddress(addressID){
+function deleteLogEmailAddress(addressID){
 
-     if (confirm(_("Do you really want to delete this email address?")) == true) {
-	$.ajax({
-          type:       "GET",
-          url:        "ajax_processing.php",
-          cache:      false,
-          data:       "action=deleteLogEmailAddress&logEmailAddressID=" + addressID,
-          success:    function(html) {
-		  updateLogEmailAddressTable();
-          }
-       });
-     }
+   if (confirm(_("Do you really want to delete this email address?")) == true) {
+  $.ajax({
+        type:       "GET",
+        url:        "ajax_processing.php",
+        cache:      false,
+        data:       "action=deleteLogEmailAddress&logEmailAddressID=" + addressID,
+        success:    function(html) {
+        updateLogEmailAddressTable();
+        }
+     });
+   }
 
-  }
-
-
-
-
- function updateOutlierTable(){
-
-       $.ajax({
-          type:       "GET",
-          url:        "ajax_htmldata.php",
-          cache:      false,
-          data:       "action=getOutlierTable",
-          success:    function(html) {
-          	$('#div_outliers').html(html);
-          }
-      });
-
- }
-
-
-
- function emptyResponse(tableName){
- 	$('#span_' + tableName + "_response").html("");
- }
+}
 
 
 
 
-  function updateOutlier(){
+function updateOutlierTable(){
 
-	  if (validateForm() === true) {
-		$.ajax({
-		  type:       "GET",
-		  url:        "ajax_processing.php",
-		  cache:      false,
-		  data:       "action=updateOutlier&outlierID=" + $('#updateOutlierID').val() + "&overageCount=" + $('#overageCount').val() + "&overagePercent=" + $('#overagePercent').val(),
-		  success:    function(html) {
-			  updateOutlierTable();
-			  myCloseDialog();
-		  }
-	       });
+     $.ajax({
+        type:       "GET",
+        url:        "ajax_htmldata.php",
+        cache:      false,
+        data:       "action=getOutlierTable",
+        success:    function(html) {
+            $('#div_outliers').html(html);
+        }
+    });
 
-	  }
+}
 
- }
+function toggleLimitAmountInput(){
+    let disabled = !$('#lineLimitSetting').is(":checked");
+    $('#lineLimitAmount').prop('disabled', disabled);
+}
+
+function emptyResponse(tableName){
+   $('#span_' + tableName + "_response").html("");
+}
 
 
 
- //validates fields for outlier form
- function validateForm (){
- 	myReturn=0;
- 	if (!validateNumber('overageCount', _("Count over must be a number."))) myReturn="1";
- 	if (!validateNumber('overagePercent', _("% over must be a number."))) myReturn="1";
 
- 	if (myReturn == "1"){
- 		return false;
- 	}else{
- 		return true;
- 	}
+function updateOutlier(){
+
+    if (validateForm() === true) {
+      $.ajax({
+        type:       "GET",
+        url:        "ajax_processing.php",
+        cache:      false,
+        data:       "action=updateOutlier&outlierID=" + $('#updateOutlierID').val() + "&overageCount=" + $('#overageCount').val() + "&overagePercent=" + $('#overagePercent').val(),
+        success:    function(html) {
+            updateOutlierTable();
+            myCloseDialog();
+        }
+         });
+
+    }
+
+}
+
+
+
+//validates fields for outlier form
+function validateForm (){
+   myReturn=0;
+   if (!validateNumber('overageCount', _("Count over must be a number."))) myReturn="1";
+   if (!validateNumber('overagePercent', _("% over must be a number."))) myReturn="1";
+
+   if (myReturn == "1"){
+       return false;
+   }else{
+       return true;
+   }
 }
 
 

--- a/usage/uploadConfirmation.php
+++ b/usage/uploadConfirmation.php
@@ -232,9 +232,11 @@ include 'templates/header.php';
 
         $headerSet = FALSE;
         // If this is not a sushi report, need to render headers
+        $i = 0;
         if (!$fromSushi) {
           echo '<thead><tr><th>' . implode('</th><th>', $firstArray) . '</th></tr></thead>';
           $headerSet = TRUE;
+          $i++;
         }
 
         echo '<tbody>';
@@ -245,7 +247,6 @@ include 'templates/header.php';
         $lineLimitExists = ($lineLimit > 0); //The line limit exists and is greater than 0 (strings return 0)
         $checkLimit = ($limitLines && $lineLimitExists); //There is a valid line limit and limit lines is set to Y
         
-        $i = 0;
         while (!feof($file_handle)) {
           //Check if you need to check for a line limit and, if that limit is set and surpassed, stop producing the list.
           if($checkLimit && $i>$lineLimit){break;}

--- a/usage/uploadConfirmation.php
+++ b/usage/uploadConfirmation.php
@@ -220,23 +220,35 @@ include 'templates/header.php';
           <p><?php echo _('If this is incorrect, please use \'Cancel\' to go back and fix the headers of the file.'); ?></p>
         <?php endif; ?>
       
-
+      <p class="actions">
+        <input type="submit" name="submitForm" id="submitFormTop" value="<?php echo _('Confirm');?>" onclick="updateSubmit();" class="submit-button primary" />
+        <input type="button" value="<?php echo _('Cancel');?>" onClick="history.back();" class='cancel-button secondary'>
+      </p>
+      <hr>
       <table class="table-border">
 
 
 			<?php
-        $i = 0;
 
+        $headerSet = FALSE;
         // If this is not a sushi report, need to render headers
         if (!$fromSushi) {
           echo '<thead><tr><th>' . implode('</th><th>', $firstArray) . '</th></tr></thead>';
-          $i = 1;
+          $headerSet = TRUE;
         }
 
         echo '<tbody>';
-
+        //This will call on a lineLimit setting and set everything appropriately.
+        $limitLines = ($config->settings->lineLimit == "Y"); //The lineLimit setting exists and is set to "Y"
+        $lineLimit = ($limitLines) ? intval($config->settings->lineLimitAmount) : FALSE; //Get an integer value for the amount.
+        $plural = ($lineLimit > 1) ? "s" : "";
+        $lineLimitExists = ($lineLimit > 0); //The line limit exists and is greater than 0 (strings return 0)
+        $checkLimit = ($limitLines && $lineLimitExists); //There is a valid line limit and limit lines is set to Y
+        
+        $i = 0;
         while (!feof($file_handle)) {
-
+          //Check if you need to check for a line limit and, if that limit is set and surpassed, stop producing the list.
+          if($checkLimit && $i>$lineLimit){break;}
           //get each line out of the file handler
           $line = stream_get_line($file_handle, 10000000, "\n");
           //set delimiter
@@ -252,8 +264,9 @@ include 'templates/header.php';
           foreach($lineArray as $value){
             //Clean some of the data
             $display = cleanValue($value);
-            if ($i == 0) {
+            if ($headerSet == FALSE) {
               echo '<th>' . strtoupper($display) .'</th>';
+              $headerSet = TRUE;
             } else {
               echo "<td>$display</td>";
             }
@@ -264,6 +277,9 @@ include 'templates/header.php';
         fclose($file_handle);
 			?>
         </tbody>
+        <?php if($checkLimit){
+          echo "<tfoot><tr>Row limit set to {$lineLimit} Row{$plural}. Further rows not presently shown.</tr></tfoot>";
+        } ?>
       </table>
 
       <form id="confirmForm" name="confirmForm" enctype="multipart/form-data" method="post" action="uploadComplete.php">
@@ -282,8 +298,9 @@ include 'templates/header.php';
         <?php foreach($page['formValues'] as $key => $value): ?>
 				  <input type="hidden" name="<?php echo $key; ?>" value="<?php echo $value; ?>">
         <?php endforeach; ?>
+        <hr>
         <p class="actions">
-          <input type="submit" name="submitForm" id="submitForm" value="<?php echo _('Confirm');?>" onclick="updateSubmit();" class="submit-button primary" />
+          <input type="submit" name="submitForm" id="submitFormBottom" value="<?php echo _('Confirm');?>" onclick="updateSubmit();" class="submit-button primary" />
           <input type="button" value="<?php echo _('Cancel');?>" onClick="history.back();" class='cancel-button secondary'>
         </p>
 			</form>


### PR DESCRIPTION
Resolves both parts of [Issue 723](https://github.com/coral-erm/coral/issues/723):
1. Adds copies of the Confirm and Cancel buttons above the Table.
2. Adds functionality to let users limit the number of rows that get loaded into the uploadConfirmation table, mainly to assist when users are loading large tables that hang up the script. Future functionality might be to load a paging system (rather than completely cutting off the table) that allows users to validate all data without loading every row in a single go. However, given the timing I decided to just go for the most direct solution.

As part of the row limit functionality, I created a section on the Usage Module's admin page that will allow users to toggle the Line Limits setting via a checkbox, and to then select how many Rows they wanted to limit their tables by. By default the module works the way it's always worked (loading every line), even if the setting doesn't exist in the configuration.ini file. Updating the setting in the Admin section should create the settings in the configuration file _and_ set them appropriately; it's the one part that I'm a little worried about. It worked in my testing environment but there are so few instances of CORAL editing the configuration.ini file (outside of the installation process) that I'm not sure if I'm missing a step somewhere. I would _highly, highly, highly_ recommend a second test from another party before merging into the new branch. 

Worth noting that the config_set() function is a slight variation of a [Stack Overflow function written by mtoloo](https://stackoverflow.com/a/36997282). The only real difference is that I preferred to set the setting sections to an array and implode them (like the individual settings) than string them together. 